### PR TITLE
[deployment-chart 0.12.0]: support pod disruption budget

### DIFF
--- a/deployment-chart/CHANGE_LOG.md
+++ b/deployment-chart/CHANGE_LOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.12.0
+- feat: support pdb for pods
+
 ## 0.11.0
 - feat: support aws target group binding
 

--- a/deployment-chart/Chart.yaml
+++ b/deployment-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: A Helm chart for Kubernetes Deployment Object in Annuums
 name: deployment-chart
 type: application
-version: 0.11.0
+version: 0.12.0

--- a/deployment-chart/templates/_helpers.tpl
+++ b/deployment-chart/templates/_helpers.tpl
@@ -47,3 +47,12 @@ helm.sh/chart: {{ include "annuums-deployment.chart" . }}
 app.kubernetes.io/version: {{ include "annuums-deployment.appVersion" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Check if both minAvailable and maxUnavailable are set.
+*/}}
+{{- define "validate.pdbAvailability" -}}
+  {{- if and (not (empty .minAvailable)) (not (empty .maxUnavailable)) -}}
+    {{- fail "Error: Both minAvailable and maxUnavailable are set in PodDisruptionBudget. Please set only one." -}}
+  {{- end -}}
+{{- end -}}

--- a/deployment-chart/templates/pdb.yaml
+++ b/deployment-chart/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- with .Values.containers }}
+{{- range .}}
+{{- $index := 0 }}
+{{- if and .pdb .pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "annuums-deployment.fullname" $ }}-{{ $index }}
+  namespace: {{ template "annuums-deployment.namespace" $ }}
+spec:
+  maxUnavailable: {{ .pdb.maxUnavailable }}
+  minAvailable: {{ .pdb.minAvailable }}
+  selector:
+    matchLabels:
+      annuums.devops/name: {{ include "annuums-deployment.fullname" $ }}-selector
+{{- $index = add $index 1 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deployment-chart/templates/pdb.yaml
+++ b/deployment-chart/templates/pdb.yaml
@@ -2,6 +2,7 @@
 {{- range .}}
 {{- $index := 0 }}
 {{- if and .pdb .pdb.enabled }}
+{{ include "validate.pdbAvailability" .pdb }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/deployment-chart/test-values.yaml
+++ b/deployment-chart/test-values.yaml
@@ -81,9 +81,47 @@ containers:
         mountPath: /foo
         subPath: ./foo
         readOnly: true
-    # Resource Default
-    # cpu: 250m
-    # memory: 128Mi
+    resources:
+      cpu: 250m
+      memory: 256Mi
+    ports:
+      - containerPort: 5050
+        protocol: TCP
+  - name: pigeon-2-pdb
+    pdb:
+      enabled: true
+      minAvailable: 1
+      maxUnavailable: 1
+    lifecycle:
+      preStop:
+        exec:
+          command:
+            - "sh"
+            - "-c"
+            - "sleep 30"
+      postStart:
+        exec:
+          command:
+            - "sh"
+    labels:
+      test-label: "pigeon-1"
+      test-label-another: "pigeon-another"
+    annotations:
+      test-annotatino-second: "pigeon-1-a"
+      test-annotatino-first: "pigeon-1-b"
+    image:
+      repository: first-rep
+      tag: 1.0.0
+    args:
+      - "while true; do sllep 30; done;"
+    command:
+      - "sh"
+      - "-c"
+    volumeMounts:
+      - name: hostpath-volume
+        mountPath: /foo
+        subPath: ./foo
+        readOnly: true
     resources:
       cpu: 250m
       memory: 256Mi

--- a/deployment-chart/test-values.yaml
+++ b/deployment-chart/test-values.yaml
@@ -87,11 +87,50 @@ containers:
     ports:
       - containerPort: 5050
         protocol: TCP
-  - name: pigeon-2-pdb
+  - name: pigeon-2-pdb-max-unavailable
+    pdb:
+      enabled: true
+      maxUnavailable: 1
+    lifecycle:
+      preStop:
+        exec:
+          command:
+            - "sh"
+            - "-c"
+            - "sleep 30"
+      postStart:
+        exec:
+          command:
+            - "sh"
+    labels:
+      test-label: "pigeon-1"
+      test-label-another: "pigeon-another"
+    annotations:
+      test-annotatino-second: "pigeon-1-a"
+      test-annotatino-first: "pigeon-1-b"
+    image:
+      repository: first-rep
+      tag: 1.0.0
+    args:
+      - "while true; do sllep 30; done;"
+    command:
+      - "sh"
+      - "-c"
+    volumeMounts:
+      - name: hostpath-volume
+        mountPath: /foo
+        subPath: ./foo
+        readOnly: true
+    resources:
+      cpu: 250m
+      memory: 256Mi
+    ports:
+      - containerPort: 5050
+        protocol: TCP
+  - name: pigeon-2-pdb-min-available
     pdb:
       enabled: true
       minAvailable: 1
-      maxUnavailable: 1
     lifecycle:
       preStop:
         exec:


### PR DESCRIPTION
# TL;DR;

[comment]: # "바뀐 내용을 간략하게 설명합니다. 세 줄 이상 넘어가는 경우, PR을 나누는 것을 고려해 보세요."

# Updates

[comment]: # "변경 사항을 모두 작성합니다."

This pull request introduces several changes to the `deployment-chart` to support PodDisruptionBudget (PDB) for pods and update the version. The most important changes include updating the change log, versioning, and adding PDB configurations.

### Key Changes:

**Versioning and Change Log:**
* Updated `CHANGE_LOG.md` to include a new entry for version 0.12.0 with the feature support for PDB for pods.
* Updated `Chart.yaml` to bump the chart version from 0.11.0 to 0.12.0.

**PodDisruptionBudget (PDB) Support:**
* Added a new template file `pdb.yaml` to define the PDB configuration for containers when enabled.
* Modified `test-values.yaml` to include example configurations for PDB, including `minAvailable` and `maxUnavailable` settings.

# Discussion

[comment]: # "함께 의논해야 할 사항을 모두 작성합니다."

# Checklist

- [x] PR 제목을 `[변경된 차트 명 버전] 변경된 내용`을 명령형으로 작성했습니다.
  - 예시)
    - `[Deployment-Chart 0.0.1] Fix app version`
- [x] 연관된 차트를 Labels로 표기했습니다.
- [x] Updates에 변경 사항을 자세히 기록했습니다.
- [x] 이해되지 않는 내용이나, 추가 논의 사항을 Discussion을 작성했습니다.
- [x] Self Review를 진행했습니다.
- [x] 연관된 사람을 Reviewer로 요청했습니다.
