### PR TITLE
[deployment-chart] update chart to version 0.14.0

### DIFF
--- a/deployment-chart/CHANGE_LOG.md
+++ b/deployment-chart/CHANGE_LOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.14.0
+- feat: support custom selector for service
+
 ## 0.13.1
 - fix: pdb template yaml error
 - fix: service template indent error

--- a/deployment-chart/Chart.yaml
+++ b/deployment-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: A Helm chart for Kubernetes Deployment Object in Annuums
 name: deployment-chart
 type: application
-version: 0.13.1
+version: 0.14.0

--- a/deployment-chart/templates/_helpers.tpl
+++ b/deployment-chart/templates/_helpers.tpl
@@ -42,7 +42,11 @@ Create a default appVersion.
 Common labels
 */}}
 {{- define "annuums-deployment.labels" -}}
+{{- if .Values.service.selector }}
+{{- toYaml $.Values.service.selector }}
+{{- else }}
 annuums.devops/name: {{ include "annuums-deployment.fullname" . }}-selector
+{{- end }}
 helm.sh/chart: {{ include "annuums-deployment.chart" . }}
 app.kubernetes.io/version: {{ include "annuums-deployment.appVersion" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/deployment-chart/templates/deployment.yaml
+++ b/deployment-chart/templates/deployment.yaml
@@ -20,7 +20,11 @@ spec:
   revisionHistoryLimit: {{ default 3 .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
+      {{- if .Values.service.selector }}
+      {{- toYaml .Values.service.selector | nindent 6 }}
+      {{- else }}
       annuums.devops/name: {{ include "annuums-deployment.fullname" . }}-selector
+      {{- end }}
   template:
     metadata:
   {{- with .Values.containers }}

--- a/deployment-chart/templates/pdb.yaml
+++ b/deployment-chart/templates/pdb.yaml
@@ -13,7 +13,11 @@ spec:
   maxUnavailable: {{ .pdb.maxUnavailable }}
   selector:
     matchLabels:
+      {{- if $.Values.service.selector }}
+      {{- toYaml $.Values.service.selector | nindent 6 }}
+      {{- else }}
       annuums.devops/name: {{ include "annuums-deployment.fullname" $ }}-selector
+      {{- end }}
   {{- end }}
 
   {{- if .pdb.minAvailable }}
@@ -27,7 +31,11 @@ spec:
   minAvailable: {{ .pdb.minAvailable }}
   selector:
     matchLabels:
+      {{- if $.Values.service.selector }}
+      {{- toYaml $.Values.service.selector | nindent 6 }}
+      {{- else }}
       annuums.devops/name: {{ include "annuums-deployment.fullname" $ }}-selector
+      {{- end }}
   {{- end }}
   
   {{- end }}

--- a/deployment-chart/templates/service.yaml
+++ b/deployment-chart/templates/service.yaml
@@ -31,5 +31,9 @@ spec:
   {{- end }}
   {{- end }}
   selector:
+    {{- if .Values.service.selector }}
+    {{- toYaml .Values.service.selector | nindent 4 }}
+    {{- else }}
     annuums.devops/name: {{ template "annuums-deployment.fullname" . }}-selector
+    {{- end }}
 {{- end }}

--- a/deployment-chart/templates/service.yaml
+++ b/deployment-chart/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- if .Values.labels }}
     {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.service.annotations }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}

--- a/deployment-chart/test-values.yaml
+++ b/deployment-chart/test-values.yaml
@@ -23,6 +23,8 @@ imagePullSecrets:
 service:
   create: true
   name: pigeon-service
+  selector:
+    annuums.devops/name: pigeon-custom-selector
   labels:
     annuums.label/pigeon: true
   annotations:

--- a/deployment-chart/test-values.yaml
+++ b/deployment-chart/test-values.yaml
@@ -23,6 +23,8 @@ imagePullSecrets:
 service:
   create: true
   name: pigeon-service
+  labels:
+    annuums.label/pigeon: true
   annotations:
     cloud.google.com/neg: '{"exposed_ports": {"3000":{"name": "devops-default-be-test"}}}'
   ports:


### PR DESCRIPTION
# TL;DR;

[comment]: # "바뀐 내용을 간략하게 설명합니다. 세 줄 이상 넘어가는 경우, PR을 나누는 것을 고려해 보세요."
- feat: support custom selector label for service

# Updates

[comment]: # "변경 사항을 모두 작성합니다."

This pull request introduces support for custom selectors in the `deployment-chart` Helm chart, along with associated updates to templates and configuration files. The changes ensure flexibility in specifying selectors, labels, and annotations for services, deployments, and other Kubernetes resources.

### New Feature: Support for Custom Selectors
* Added support for custom selectors in the Helm chart templates, including `service.yaml`, `deployment.yaml`, and `pdb.yaml`, allowing users to define their own selector values via `Values.service.selector` (`[[1]](diffhunk://#diff-abf1654bd4bb31c875c376c9ba7b97b051f6d8e27a7d587586fa0cbbfe4b79d6R45-R49)`, `[[2]](diffhunk://#diff-6c13b59d2726905b02ef37ee5f02e9388bd24986d1a96f4e0df8ec7ec5990515R23-R27)`, `[[3]](diffhunk://#diff-ae02fa1fd7ba756703dd776751a7250ab14658efe5c74038aa30396539e96960R16-R21)`, `[[4]](diffhunk://#diff-ae02fa1fd7ba756703dd776751a7250ab14658efe5c74038aa30396539e96960R34-R39)`, `[[5]](diffhunk://#diff-6eed244fb9da2e542438d3a4a764c89a46c0d78d7b88a1c47e40a61baf41f6a2R34-R39)`).
* Updated the `test-values.yaml` file to include an example of a custom selector and associated labels (`[deployment-chart/test-values.yamlR26-R29](diffhunk://#diff-9fe20f8453d720461def214b646b342f61b62fc7e48e157c41ea29a83ca5da12R26-R29)`).

### Helm Chart Version Update
* Incremented the chart version from `0.13.1` to `0.14.0` in `Chart.yaml` to reflect the new feature addition (`[deployment-chart/Chart.yamlL5-R5](diffhunk://#diff-6093ac21add1b666e04e9045f29477521f9259264bee9e2b8aa03c13a7b3b570L5-R5)`).
* Documented the new feature in the `CHANGE_LOG.md` file under version `0.14.0` (`[deployment-chart/CHANGE_LOG.mdR3-R5](diffhunk://#diff-d62466702f7bc5c5cf0fa045e658d7aca2c02401e5d61c47a3ff82b19fa071a6R3-R5)`).

### Enhancements to Service Configuration
* Added support for custom labels in `service.yaml` via `Values.service.labels`, allowing users to define additional labels for services (`[deployment-chart/templates/service.yamlR13-R15](diffhunk://#diff-6eed244fb9da2e542438d3a4a764c89a46c0d78d7b88a1c47e40a61baf41f6a2R13-R15)`).

# Discussion

[comment]: # "함께 의논해야 할 사항을 모두 작성합니다."

# Checklist

- [x] PR 제목을 `[변경된 차트 명 버전] 변경된 내용`을 명령형으로 작성했습니다.
  - 예시)
    - `[Deployment-Chart 0.0.1] Fix app version`
- [x] 연관된 차트를 Labels로 표기했습니다.
- [x] Updates에 변경 사항을 자세히 기록했습니다.
- [x] 이해되지 않는 내용이나, 추가 논의 사항을 Discussion을 작성했습니다.
- [x] Self Review를 진행했습니다.
- [x] 연관된 사람을 Reviewer로 요청했습니다.
