### PR TITLE
update: [cronjob-chart] prevent empty annotations

### DIFF
--- a/cronjob-chart/CHANGE_LOG.md
+++ b/cronjob-chart/CHANGE_LOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.6
+- fix: prevent empty annotations from being rendered in templates
+
 ## 0.7.5
 - fix: set common annotations for pod and cronjob object
 

--- a/cronjob-chart/Chart.yaml
+++ b/cronjob-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: A Helm chart for Kubernetes CronJob Object in Annuums
 name: cronjob-chart
 type: application
-version: 0.7.5
+version: 0.7.6

--- a/cronjob-chart/templates/cronjob.yaml
+++ b/cronjob-chart/templates/cronjob.yaml
@@ -5,10 +5,10 @@ kind: CronJob
 metadata:
   name: {{ template "annuums-cronjob.fullname" . }}
   namespace: {{ template "annuums-cronjob.namespace" . }}
+  {{- if .Values.annotations }}
   annotations:
-    {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | nindent 4 }}
-    {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/cronjob: {{ template "annuums-cronjob.fullname" . }}
     annuums.obs/version: {{ template "annuums-cronjob.chart" . }}
@@ -26,10 +26,10 @@ spec:
       activeDeadlineSeconds: {{ default 600 .Values.cronjob.activeDeadlineSeconds }}
       template:
         metadata:
+          {{- if .Values.annotations }}
           annotations:
-            {{- if .Values.annotations }}
             {{- toYaml .Values.annotations | nindent 12}}
-            {{- end }}
+          {{- end }}
           labels:
             app.kubernetes.io/cronjob: {{ template "annuums-cronjob.fullname" $ }}
             annuums.obs/version: {{ template "annuums-cronjob.chart" $ }}

--- a/cronjob-chart/test-values.yaml
+++ b/cronjob-chart/test-values.yaml
@@ -19,7 +19,7 @@ imagePullSecrets:
   - name: my-registry-secret-2
 
 annotations:
-  annuums.devops/pigeon: true
+  annuums.devops/pigeon: pigeon
 
 cronjob:
   name: pigeon-cron-job


### PR DESCRIPTION
# TL;DR;

- cronjob 버전을 업데이트합니다. (0.7.6)
 
# Updates

- annotations를 조건부로 렌더링하도록 수정하여, 값이 없으면 YAML에 나타나지 않도록 개선


# Checklist

- [x] PR 제목을 `[변경된 차트 명 버전] 변경된 내용`을 명령형으로 작성했습니다.
  - 예시)
    - `[Deployment-Chart 0.0.1] Fix app version`
- [x] 연관된 차트를 Labels로 표기했습니다.
- [x] Updates에 변경 사항을 자세히 기록했습니다.
- [x] 이해되지 않는 내용이나, 추가 논의 사항을 Discussion을 작성했습니다.
- [x] Self Review를 진행했습니다.
- [x] 연관된 사람을 Reviewer로 요청했습니다.
