### PR TITLE
Gateway chart 0.1.0

### DIFF
--- a/gateway-chart/CHANGE_LOG.md
+++ b/gateway-chart/CHANGE_LOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 0.1.0
+- fix: remove `namespace` field from GatewayClass (cluster-scoped resource)
+- fix: `allowedRoutes` in Gateway listener was hardcoded to `from: Selector` — now configurable
+- fix: `hostnames` in HTTPRoute/GRPCRoute now optional (rendered only when set)
+- fix: `httpRoutes` and `grpcRoutes` changed from single object to list to support multiple routes per release
+- feat: add `parametersRef` and `description` fields to GatewayClass
+- feat: add `addresses` and `infrastructure` fields to Gateway (GA in v1.2)
+- feat: add `TLSRoute` template (promoted to Standard in Gateway API v1.5)
+- feat: add `ReferenceGrant` template (for cross-namespace access)
+- feat: add `LoadBalancerConfiguration` template (AWS LBC custom CRD)
+- feat: add `TargetGroupConfiguration` template (AWS LBC custom CRD)
+- refactor: `namespace` in values.yaml → `namespaceOverride` (aligns with _helpers.tpl)
+
 ## 0.0.6
 - fix: fix missing `tls` field in template
 

--- a/gateway-chart/Chart.yaml
+++ b/gateway-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: A Helm chart for Kubernetes Gateway API in Annuums
 name: gateway-chart
 type: application
-version: 0.0.6
+version: 0.1.0

--- a/gateway-chart/templates/_helpers.tpl
+++ b/gateway-chart/templates/_helpers.tpl
@@ -17,11 +17,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Allow the release namespace to be overridden for multi-namespace gateways in combined charts
 */}}
 {{- define "annuums-gateway.namespace" -}}
-  {{- if .Values.namespaceOverride }}
-    {{- .Values.namespaceOverride -}}
-  {{- else }}
-    {{- .Release.Namespace -}}
-  {{- end }}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/gateway-chart/templates/gateway-class.yaml
+++ b/gateway-chart/templates/gateway-class.yaml
@@ -2,7 +2,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  name: {{ .Values.gatewayClass.name }}
+  name: {{ required "gatewayClass.name is required" .Values.gatewayClass.name }}
   labels:
     {{- include "annuums-gateway.labels" . | nindent 4 }}
     {{- if .Values.gatewayClass.labels }}
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml .Values.gatewayClass.annotations | nindent 4 }}
   {{- end }}
 spec:
-  controllerName: {{ .Values.gatewayClass.controllerName }}
+  controllerName: {{ required "gatewayClass.controllerName is required" .Values.gatewayClass.controllerName }}
   {{- if .Values.gatewayClass.parametersRef }}
   parametersRef:
     {{- toYaml .Values.gatewayClass.parametersRef | nindent 4 }}

--- a/gateway-chart/templates/gateway-class.yaml
+++ b/gateway-chart/templates/gateway-class.yaml
@@ -3,7 +3,6 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: {{ .Values.gatewayClass.name }}
-  namespace: {{ template "annuums-gateway.namespace" . }}
   labels:
     {{- include "annuums-gateway.labels" . | nindent 4 }}
     {{- if .Values.gatewayClass.labels }}
@@ -15,4 +14,11 @@ metadata:
   {{- end }}
 spec:
   controllerName: {{ .Values.gatewayClass.controllerName }}
+  {{- if .Values.gatewayClass.parametersRef }}
+  parametersRef:
+    {{- toYaml .Values.gatewayClass.parametersRef | nindent 4 }}
+  {{- end }}
+  {{- if .Values.gatewayClass.description }}
+  description: {{ .Values.gatewayClass.description | quote }}
+  {{- end }}
 {{- end }}

--- a/gateway-chart/templates/gateway.yaml
+++ b/gateway-chart/templates/gateway.yaml
@@ -2,7 +2,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: {{ .Values.gateway.name }}
+  name: {{ required "gateway.name is required" .Values.gateway.name }}
   namespace: {{ template "annuums-gateway.namespace" . }}
   labels:
     {{- include "annuums-gateway.labels" . | nindent 4 }}
@@ -14,38 +14,39 @@ metadata:
     {{- toYaml .Values.gateway.annotations | nindent 4 }}
   {{- end }}
 spec:
-  gatewayClassName: {{ .Values.gateway.className }}
+  gatewayClassName: {{ required "gateway.className is required" .Values.gateway.className }}
   listeners:
-    {{- with .Values.gateway.listeners }}
-    {{- range . }}
-    - name: {{ .name }}
-      protocol: {{ .protocol }}
-      {{- if .hostname }}
-      hostname: {{ .hostname }}
+    {{- if not .Values.gateway.listeners }}
+    {{- fail "gateway.listeners is required and must not be empty" }}
+    {{- end }}
+    {{- range $i, $listener := .Values.gateway.listeners }}
+    - name: {{ required (printf "gateway.listeners[%d].name is required" $i) $listener.name }}
+      protocol: {{ required (printf "gateway.listeners[%d].protocol is required" $i) $listener.protocol }}
+      {{- if $listener.hostname }}
+      hostname: {{ $listener.hostname }}
       {{- end }}
-      {{- if .port }}
-      port: {{ .port }}
+      {{- if $listener.port }}
+      port: {{ $listener.port }}
       {{- end }}
-      {{- if .allowedRoutes }}
+      {{- if $listener.allowedRoutes }}
       allowedRoutes:
-        {{- if .allowedRoutes.namespaces }}
+        {{- if $listener.allowedRoutes.namespaces }}
         namespaces:
-          from: {{ required "allowedRoutes.namespaces.from is required" .allowedRoutes.namespaces.from }}
-          {{- if eq .allowedRoutes.namespaces.from "Selector" }}
+          from: {{ required (printf "gateway.listeners[%d].allowedRoutes.namespaces.from is required" $i) $listener.allowedRoutes.namespaces.from }}
+          {{- if eq $listener.allowedRoutes.namespaces.from "Selector" }}
           selector:
-            {{- toYaml (required "allowedRoutes.namespaces.selector is required when from is Selector" .allowedRoutes.namespaces.selector) | nindent 12 }}
+            {{- toYaml (required (printf "gateway.listeners[%d].allowedRoutes.namespaces.selector is required when from is Selector" $i) $listener.allowedRoutes.namespaces.selector) | nindent 12 }}
           {{- end }}
         {{- end }}
-        {{- if .allowedRoutes.kinds }}
+        {{- if $listener.allowedRoutes.kinds }}
         kinds:
-          {{- toYaml .allowedRoutes.kinds | nindent 10 }}
+          {{- toYaml $listener.allowedRoutes.kinds | nindent 10 }}
         {{- end }}
       {{- end }}
-      {{- if .tls }}
+      {{- if $listener.tls }}
       tls:
-        {{- toYaml .tls | nindent 8 }}
+        {{- toYaml $listener.tls | nindent 8 }}
       {{- end }}
-    {{- end }}
     {{- end }}
   {{- if .Values.gateway.addresses }}
   addresses:

--- a/gateway-chart/templates/gateway.yaml
+++ b/gateway-chart/templates/gateway.yaml
@@ -28,11 +28,18 @@ spec:
       {{- end }}
       {{- if .allowedRoutes }}
       allowedRoutes:
+        {{- if .allowedRoutes.namespaces }}
         namespaces:
-          from: Selector
+          from: {{ .allowedRoutes.namespaces.from }}
+          {{- if .allowedRoutes.namespaces.selector }}
           selector:
-            matchLabels:
-              {{- toYaml .allowedRoutes.matchLabels | nindent 14 }}
+            {{- toYaml .allowedRoutes.namespaces.selector | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if .allowedRoutes.kinds }}
+        kinds:
+          {{- toYaml .allowedRoutes.kinds | nindent 10 }}
+        {{- end }}
       {{- end }}
       {{- if .tls }}
       tls:
@@ -40,4 +47,12 @@ spec:
       {{- end }}
     {{- end }}
     {{- end }}
+  {{- if .Values.gateway.addresses }}
+  addresses:
+    {{- toYaml .Values.gateway.addresses | nindent 4 }}
+  {{- end }}
+  {{- if .Values.gateway.infrastructure }}
+  infrastructure:
+    {{- toYaml .Values.gateway.infrastructure | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/gateway-chart/templates/gateway.yaml
+++ b/gateway-chart/templates/gateway.yaml
@@ -25,9 +25,7 @@ spec:
       {{- if $listener.hostname }}
       hostname: {{ $listener.hostname }}
       {{- end }}
-      {{- if $listener.port }}
-      port: {{ $listener.port }}
-      {{- end }}
+      port: {{ required (printf "gateway.listeners[%d].port is required" $i) $listener.port }}
       {{- if $listener.allowedRoutes }}
       allowedRoutes:
         {{- if $listener.allowedRoutes.namespaces }}

--- a/gateway-chart/templates/gateway.yaml
+++ b/gateway-chart/templates/gateway.yaml
@@ -18,6 +18,8 @@ spec:
   listeners:
     {{- if not .Values.gateway.listeners }}
     {{- fail "gateway.listeners is required and must not be empty" }}
+    {{- else if not (kindIs "slice" .Values.gateway.listeners) }}
+    {{- fail "gateway.listeners must be a list ([])" }}
     {{- end }}
     {{- range $i, $listener := .Values.gateway.listeners }}
     - name: {{ required (printf "gateway.listeners[%d].name is required" $i) $listener.name }}

--- a/gateway-chart/templates/gateway.yaml
+++ b/gateway-chart/templates/gateway.yaml
@@ -30,10 +30,10 @@ spec:
       allowedRoutes:
         {{- if .allowedRoutes.namespaces }}
         namespaces:
-          from: {{ .allowedRoutes.namespaces.from }}
-          {{- if .allowedRoutes.namespaces.selector }}
+          from: {{ required "allowedRoutes.namespaces.from is required" .allowedRoutes.namespaces.from }}
+          {{- if eq .allowedRoutes.namespaces.from "Selector" }}
           selector:
-            {{- toYaml .allowedRoutes.namespaces.selector | nindent 12 }}
+            {{- toYaml (required "allowedRoutes.namespaces.selector is required when from is Selector" .allowedRoutes.namespaces.selector) | nindent 12 }}
           {{- end }}
         {{- end }}
         {{- if .allowedRoutes.kinds }}

--- a/gateway-chart/templates/grpc-routes.yaml
+++ b/gateway-chart/templates/grpc-routes.yaml
@@ -16,11 +16,11 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml .parentRefs | nindent 4 }}
+    {{- toYaml (required (printf "grpcRoutes[%s].parentRefs is required" .name) .parentRefs) | nindent 4 }}
   {{- if .hostnames }}
   hostnames:
     {{- toYaml .hostnames | nindent 4 }}
   {{- end }}
   rules:
-    {{- toYaml .rules | nindent 4 }}
+    {{- toYaml (required (printf "grpcRoutes[%s].rules is required" .name) .rules) | nindent 4 }}
 {{- end }}

--- a/gateway-chart/templates/grpc-routes.yaml
+++ b/gateway-chart/templates/grpc-routes.yaml
@@ -1,4 +1,4 @@
-{{- if not (kindIs "slice" .Values.grpcRoutes) }}
+{{- if and .Values.grpcRoutes (not (kindIs "slice" .Values.grpcRoutes)) }}
   {{- fail "grpcRoutes must be a list ([]). If upgrading from v0.0.x, migrate from object to list form. See CHANGE_LOG.md" }}
 {{- end }}
 {{- range $i, $route := .Values.grpcRoutes }}

--- a/gateway-chart/templates/grpc-routes.yaml
+++ b/gateway-chart/templates/grpc-routes.yaml
@@ -1,23 +1,26 @@
-{{- if .Values.grpcRoutes }}
+{{- range .Values.grpcRoutes }}
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
-  name: {{ .Values.grpcRoutes.name }}
-  namespace: {{ template "annuums-gateway.namespace" . }}
+  name: {{ .name }}
+  namespace: {{ template "annuums-gateway.namespace" $ }}
   labels:
-    {{- include "annuums-gateway.labels" . | nindent 4 }}
-    {{- if .Values.grpcRoutes.labels }}
-    {{- toYaml .Values.grpcRoutes.labels | nindent 4 }}
+    {{- include "annuums-gateway.labels" $ | nindent 4 }}
+    {{- if .labels }}
+    {{- toYaml .labels | nindent 4 }}
     {{- end }}
-  {{- if .Values.grpcRoutes.annotations }}
+  {{- if .annotations }}
   annotations:
-    {{- toYaml .Values.grpcRoutes.annotations | nindent 4 }}
+    {{- toYaml .annotations | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml .Values.grpcRoutes.parentRefs | nindent 4 }}
+    {{- toYaml .parentRefs | nindent 4 }}
+  {{- if .hostnames }}
   hostnames:
-    {{- toYaml .Values.grpcRoutes.hostnames | nindent 4 }}
+    {{- toYaml .hostnames | nindent 4 }}
+  {{- end }}
   rules:
-    {{- toYaml .Values.grpcRoutes.rules | nindent 4 }}
+    {{- toYaml .rules | nindent 4 }}
 {{- end }}

--- a/gateway-chart/templates/grpc-routes.yaml
+++ b/gateway-chart/templates/grpc-routes.yaml
@@ -1,3 +1,6 @@
+{{- if not (kindIs "slice" .Values.grpcRoutes) }}
+  {{- fail "grpcRoutes must be a list ([]). If upgrading from v0.0.x, migrate from object to list form. See CHANGE_LOG.md" }}
+{{- end }}
 {{- range $i, $route := .Values.grpcRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1

--- a/gateway-chart/templates/grpc-routes.yaml
+++ b/gateway-chart/templates/grpc-routes.yaml
@@ -1,26 +1,26 @@
-{{- range .Values.grpcRoutes }}
+{{- range $i, $route := .Values.grpcRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
-  name: {{ .name }}
+  name: {{ required (printf "grpcRoutes[%d].name is required" $i) $route.name }}
   namespace: {{ template "annuums-gateway.namespace" $ }}
   labels:
     {{- include "annuums-gateway.labels" $ | nindent 4 }}
-    {{- if .labels }}
-    {{- toYaml .labels | nindent 4 }}
+    {{- if $route.labels }}
+    {{- toYaml $route.labels | nindent 4 }}
     {{- end }}
-  {{- if .annotations }}
+  {{- if $route.annotations }}
   annotations:
-    {{- toYaml .annotations | nindent 4 }}
+    {{- toYaml $route.annotations | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml (required (printf "grpcRoutes[%s].parentRefs is required" .name) .parentRefs) | nindent 4 }}
-  {{- if .hostnames }}
+    {{- toYaml (required (printf "grpcRoutes[%d].parentRefs is required" $i) $route.parentRefs) | nindent 4 }}
+  {{- if $route.hostnames }}
   hostnames:
-    {{- toYaml .hostnames | nindent 4 }}
+    {{- toYaml $route.hostnames | nindent 4 }}
   {{- end }}
   rules:
-    {{- toYaml (required (printf "grpcRoutes[%s].rules is required" .name) .rules) | nindent 4 }}
+    {{- toYaml (required (printf "grpcRoutes[%d].rules is required" $i) $route.rules) | nindent 4 }}
 {{- end }}

--- a/gateway-chart/templates/http-routes.yaml
+++ b/gateway-chart/templates/http-routes.yaml
@@ -1,4 +1,4 @@
-{{- if not (kindIs "slice" .Values.httpRoutes) }}
+{{- if and .Values.httpRoutes (not (kindIs "slice" .Values.httpRoutes)) }}
   {{- fail "httpRoutes must be a list ([]). If upgrading from v0.0.x, migrate from object to list form. See CHANGE_LOG.md" }}
 {{- end }}
 {{- range $i, $route := .Values.httpRoutes }}

--- a/gateway-chart/templates/http-routes.yaml
+++ b/gateway-chart/templates/http-routes.yaml
@@ -1,26 +1,26 @@
-{{- range .Values.httpRoutes }}
+{{- range $i, $route := .Values.httpRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ .name }}
+  name: {{ required (printf "httpRoutes[%d].name is required" $i) $route.name }}
   namespace: {{ template "annuums-gateway.namespace" $ }}
   labels:
     {{- include "annuums-gateway.labels" $ | nindent 4 }}
-    {{- if .labels }}
-    {{- toYaml .labels | nindent 4 }}
+    {{- if $route.labels }}
+    {{- toYaml $route.labels | nindent 4 }}
     {{- end }}
-  {{- if .annotations }}
+  {{- if $route.annotations }}
   annotations:
-    {{- toYaml .annotations | nindent 4 }}
+    {{- toYaml $route.annotations | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml (required (printf "httpRoutes[%s].parentRefs is required" .name) .parentRefs) | nindent 4 }}
-  {{- if .hostnames }}
+    {{- toYaml (required (printf "httpRoutes[%d].parentRefs is required" $i) $route.parentRefs) | nindent 4 }}
+  {{- if $route.hostnames }}
   hostnames:
-    {{- toYaml .hostnames | nindent 4 }}
+    {{- toYaml $route.hostnames | nindent 4 }}
   {{- end }}
   rules:
-    {{- toYaml (required (printf "httpRoutes[%s].rules is required" .name) .rules) | nindent 4 }}
+    {{- toYaml (required (printf "httpRoutes[%d].rules is required" $i) $route.rules) | nindent 4 }}
 {{- end }}

--- a/gateway-chart/templates/http-routes.yaml
+++ b/gateway-chart/templates/http-routes.yaml
@@ -16,11 +16,11 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml .parentRefs | nindent 4 }}
+    {{- toYaml (required (printf "httpRoutes[%s].parentRefs is required" .name) .parentRefs) | nindent 4 }}
   {{- if .hostnames }}
   hostnames:
     {{- toYaml .hostnames | nindent 4 }}
   {{- end }}
   rules:
-    {{- toYaml .rules | nindent 4 }}
+    {{- toYaml (required (printf "httpRoutes[%s].rules is required" .name) .rules) | nindent 4 }}
 {{- end }}

--- a/gateway-chart/templates/http-routes.yaml
+++ b/gateway-chart/templates/http-routes.yaml
@@ -1,3 +1,6 @@
+{{- if not (kindIs "slice" .Values.httpRoutes) }}
+  {{- fail "httpRoutes must be a list ([]). If upgrading from v0.0.x, migrate from object to list form. See CHANGE_LOG.md" }}
+{{- end }}
 {{- range $i, $route := .Values.httpRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1

--- a/gateway-chart/templates/load-balancer-configurations.yaml
+++ b/gateway-chart/templates/load-balancer-configurations.yaml
@@ -1,3 +1,6 @@
+{{- if not (kindIs "slice" .Values.loadBalancerConfigurations) }}
+  {{- fail "loadBalancerConfigurations must be a list ([]). See CHANGE_LOG.md" }}
+{{- end }}
 {{- range $i, $lbc := .Values.loadBalancerConfigurations }}
 ---
 apiVersion: gateway.k8s.aws/v1beta1

--- a/gateway-chart/templates/load-balancer-configurations.yaml
+++ b/gateway-chart/templates/load-balancer-configurations.yaml
@@ -1,65 +1,65 @@
-{{- range .Values.loadBalancerConfigurations }}
+{{- range $i, $lbc := .Values.loadBalancerConfigurations }}
 ---
 apiVersion: gateway.k8s.aws/v1beta1
 kind: LoadBalancerConfiguration
 metadata:
-  name: {{ .name }}
+  name: {{ required (printf "loadBalancerConfigurations[%d].name is required" $i) $lbc.name }}
   namespace: {{ template "annuums-gateway.namespace" $ }}
   labels:
     {{- include "annuums-gateway.labels" $ | nindent 4 }}
-    {{- if .labels }}
-    {{- toYaml .labels | nindent 4 }}
+    {{- if $lbc.labels }}
+    {{- toYaml $lbc.labels | nindent 4 }}
     {{- end }}
-  {{- if .annotations }}
+  {{- if $lbc.annotations }}
   annotations:
-    {{- toYaml .annotations | nindent 4 }}
+    {{- toYaml $lbc.annotations | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .targetRef }}
+  {{- if $lbc.targetRef }}
   targetRef:
-    {{- toYaml .targetRef | nindent 4 }}
+    {{- toYaml $lbc.targetRef | nindent 4 }}
   {{- end }}
-  {{- if .scheme }}
-  scheme: {{ .scheme }}
+  {{- if $lbc.scheme }}
+  scheme: {{ $lbc.scheme }}
   {{- end }}
-  {{- if .ipAddressType }}
-  ipAddressType: {{ .ipAddressType }}
+  {{- if $lbc.ipAddressType }}
+  ipAddressType: {{ $lbc.ipAddressType }}
   {{- end }}
-  {{- if .loadBalancerName }}
-  loadBalancerName: {{ .loadBalancerName }}
+  {{- if $lbc.loadBalancerName }}
+  loadBalancerName: {{ $lbc.loadBalancerName }}
   {{- end }}
-  {{- if .loadBalancerSubnets }}
+  {{- if $lbc.loadBalancerSubnets }}
   loadBalancerSubnets:
-    {{- toYaml .loadBalancerSubnets | nindent 4 }}
+    {{- toYaml $lbc.loadBalancerSubnets | nindent 4 }}
   {{- end }}
-  {{- if .loadBalancerSubnetsSelector }}
+  {{- if $lbc.loadBalancerSubnetsSelector }}
   loadBalancerSubnetsSelector:
-    {{- toYaml .loadBalancerSubnetsSelector | nindent 4 }}
+    {{- toYaml $lbc.loadBalancerSubnetsSelector | nindent 4 }}
   {{- end }}
-  {{- if .securityGroups }}
+  {{- if $lbc.securityGroups }}
   securityGroups:
-    {{- toYaml .securityGroups | nindent 4 }}
+    {{- toYaml $lbc.securityGroups | nindent 4 }}
   {{- end }}
-  {{- if .sourceRanges }}
+  {{- if $lbc.sourceRanges }}
   sourceRanges:
-    {{- toYaml .sourceRanges | nindent 4 }}
+    {{- toYaml $lbc.sourceRanges | nindent 4 }}
   {{- end }}
-  {{- if .loadBalancerAttributes }}
+  {{- if $lbc.loadBalancerAttributes }}
   loadBalancerAttributes:
-    {{- toYaml .loadBalancerAttributes | nindent 4 }}
+    {{- toYaml $lbc.loadBalancerAttributes | nindent 4 }}
   {{- end }}
-  {{- if .listenerConfigurations }}
+  {{- if $lbc.listenerConfigurations }}
   listenerConfigurations:
-    {{- toYaml .listenerConfigurations | nindent 4 }}
+    {{- toYaml $lbc.listenerConfigurations | nindent 4 }}
   {{- end }}
-  {{- if .tags }}
+  {{- if $lbc.tags }}
   tags:
-    {{- toYaml .tags | nindent 4 }}
+    {{- toYaml $lbc.tags | nindent 4 }}
   {{- end }}
-  {{- if .webACL }}
-  webACL: {{ .webACL }}
+  {{- if $lbc.webACL }}
+  webACL: {{ $lbc.webACL }}
   {{- end }}
-  {{- if .mergingMode }}
-  mergingMode: {{ .mergingMode }}
+  {{- if $lbc.mergingMode }}
+  mergingMode: {{ $lbc.mergingMode }}
   {{- end }}
 {{- end }}

--- a/gateway-chart/templates/load-balancer-configurations.yaml
+++ b/gateway-chart/templates/load-balancer-configurations.yaml
@@ -1,0 +1,65 @@
+{{- range .Values.loadBalancerConfigurations }}
+---
+apiVersion: gateway.k8s.aws/v1beta1
+kind: LoadBalancerConfiguration
+metadata:
+  name: {{ .name }}
+  namespace: {{ template "annuums-gateway.namespace" $ }}
+  labels:
+    {{- include "annuums-gateway.labels" $ | nindent 4 }}
+    {{- if .labels }}
+    {{- toYaml .labels | nindent 4 }}
+    {{- end }}
+  {{- if .annotations }}
+  annotations:
+    {{- toYaml .annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .targetRef }}
+  targetRef:
+    {{- toYaml .targetRef | nindent 4 }}
+  {{- end }}
+  {{- if .scheme }}
+  scheme: {{ .scheme }}
+  {{- end }}
+  {{- if .ipAddressType }}
+  ipAddressType: {{ .ipAddressType }}
+  {{- end }}
+  {{- if .loadBalancerName }}
+  loadBalancerName: {{ .loadBalancerName }}
+  {{- end }}
+  {{- if .loadBalancerSubnets }}
+  loadBalancerSubnets:
+    {{- toYaml .loadBalancerSubnets | nindent 4 }}
+  {{- end }}
+  {{- if .loadBalancerSubnetsSelector }}
+  loadBalancerSubnetsSelector:
+    {{- toYaml .loadBalancerSubnetsSelector | nindent 4 }}
+  {{- end }}
+  {{- if .securityGroups }}
+  securityGroups:
+    {{- toYaml .securityGroups | nindent 4 }}
+  {{- end }}
+  {{- if .sourceRanges }}
+  sourceRanges:
+    {{- toYaml .sourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if .loadBalancerAttributes }}
+  loadBalancerAttributes:
+    {{- toYaml .loadBalancerAttributes | nindent 4 }}
+  {{- end }}
+  {{- if .listenerConfigurations }}
+  listenerConfigurations:
+    {{- toYaml .listenerConfigurations | nindent 4 }}
+  {{- end }}
+  {{- if .tags }}
+  tags:
+    {{- toYaml .tags | nindent 4 }}
+  {{- end }}
+  {{- if .webACL }}
+  webACL: {{ .webACL }}
+  {{- end }}
+  {{- if .mergingMode }}
+  mergingMode: {{ .mergingMode }}
+  {{- end }}
+{{- end }}

--- a/gateway-chart/templates/load-balancer-configurations.yaml
+++ b/gateway-chart/templates/load-balancer-configurations.yaml
@@ -1,4 +1,4 @@
-{{- if not (kindIs "slice" .Values.loadBalancerConfigurations) }}
+{{- if and .Values.loadBalancerConfigurations (not (kindIs "slice" .Values.loadBalancerConfigurations)) }}
   {{- fail "loadBalancerConfigurations must be a list ([]). See CHANGE_LOG.md" }}
 {{- end }}
 {{- range $i, $lbc := .Values.loadBalancerConfigurations }}

--- a/gateway-chart/templates/reference-grants.yaml
+++ b/gateway-chart/templates/reference-grants.yaml
@@ -1,3 +1,6 @@
+{{- if not (kindIs "slice" .Values.referenceGrants) }}
+  {{- fail "referenceGrants must be a list ([]). See CHANGE_LOG.md" }}
+{{- end }}
 {{- range $i, $grant := .Values.referenceGrants }}
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1

--- a/gateway-chart/templates/reference-grants.yaml
+++ b/gateway-chart/templates/reference-grants.yaml
@@ -1,7 +1,7 @@
-{{- range .Values.httpRoutes }}
+{{- range .Values.referenceGrants }}
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
 metadata:
   name: {{ .name }}
   namespace: {{ template "annuums-gateway.namespace" $ }}
@@ -15,12 +15,8 @@ metadata:
     {{- toYaml .annotations | nindent 4 }}
   {{- end }}
 spec:
-  parentRefs:
-    {{- toYaml .parentRefs | nindent 4 }}
-  {{- if .hostnames }}
-  hostnames:
-    {{- toYaml .hostnames | nindent 4 }}
-  {{- end }}
-  rules:
-    {{- toYaml .rules | nindent 4 }}
+  from:
+    {{- toYaml .from | nindent 4 }}
+  to:
+    {{- toYaml .to | nindent 4 }}
 {{- end }}

--- a/gateway-chart/templates/reference-grants.yaml
+++ b/gateway-chart/templates/reference-grants.yaml
@@ -1,4 +1,4 @@
-{{- if not (kindIs "slice" .Values.referenceGrants) }}
+{{- if and .Values.referenceGrants (not (kindIs "slice" .Values.referenceGrants)) }}
   {{- fail "referenceGrants must be a list ([]). See CHANGE_LOG.md" }}
 {{- end }}
 {{- range $i, $grant := .Values.referenceGrants }}

--- a/gateway-chart/templates/reference-grants.yaml
+++ b/gateway-chart/templates/reference-grants.yaml
@@ -1,22 +1,22 @@
-{{- range .Values.referenceGrants }}
+{{- range $i, $grant := .Values.referenceGrants }}
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: {{ .name }}
+  name: {{ required (printf "referenceGrants[%d].name is required" $i) $grant.name }}
   namespace: {{ template "annuums-gateway.namespace" $ }}
   labels:
     {{- include "annuums-gateway.labels" $ | nindent 4 }}
-    {{- if .labels }}
-    {{- toYaml .labels | nindent 4 }}
+    {{- if $grant.labels }}
+    {{- toYaml $grant.labels | nindent 4 }}
     {{- end }}
-  {{- if .annotations }}
+  {{- if $grant.annotations }}
   annotations:
-    {{- toYaml .annotations | nindent 4 }}
+    {{- toYaml $grant.annotations | nindent 4 }}
   {{- end }}
 spec:
   from:
-    {{- toYaml .from | nindent 4 }}
+    {{- toYaml (required (printf "referenceGrants[%d].from is required" $i) $grant.from) | nindent 4 }}
   to:
-    {{- toYaml .to | nindent 4 }}
+    {{- toYaml (required (printf "referenceGrants[%d].to is required" $i) $grant.to) | nindent 4 }}
 {{- end }}

--- a/gateway-chart/templates/target-group-configurations.yaml
+++ b/gateway-chart/templates/target-group-configurations.yaml
@@ -1,3 +1,6 @@
+{{- if not (kindIs "slice" .Values.targetGroupConfigurations) }}
+  {{- fail "targetGroupConfigurations must be a list ([]). See CHANGE_LOG.md" }}
+{{- end }}
 {{- range $i, $tgc := .Values.targetGroupConfigurations }}
 ---
 apiVersion: gateway.k8s.aws/v1beta1

--- a/gateway-chart/templates/target-group-configurations.yaml
+++ b/gateway-chart/templates/target-group-configurations.yaml
@@ -1,0 +1,28 @@
+{{- range .Values.targetGroupConfigurations }}
+---
+apiVersion: gateway.k8s.aws/v1beta1
+kind: TargetGroupConfiguration
+metadata:
+  name: {{ .name }}
+  namespace: {{ template "annuums-gateway.namespace" $ }}
+  labels:
+    {{- include "annuums-gateway.labels" $ | nindent 4 }}
+    {{- if .labels }}
+    {{- toYaml .labels | nindent 4 }}
+    {{- end }}
+  {{- if .annotations }}
+  annotations:
+    {{- toYaml .annotations | nindent 4 }}
+  {{- end }}
+spec:
+  targetReference:
+    {{- toYaml .targetReference | nindent 4 }}
+  {{- if .defaultConfiguration }}
+  defaultConfiguration:
+    {{- toYaml .defaultConfiguration | nindent 4 }}
+  {{- end }}
+  {{- if .routeConfigurations }}
+  routeConfigurations:
+    {{- toYaml .routeConfigurations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/gateway-chart/templates/target-group-configurations.yaml
+++ b/gateway-chart/templates/target-group-configurations.yaml
@@ -1,28 +1,28 @@
-{{- range .Values.targetGroupConfigurations }}
+{{- range $i, $tgc := .Values.targetGroupConfigurations }}
 ---
 apiVersion: gateway.k8s.aws/v1beta1
 kind: TargetGroupConfiguration
 metadata:
-  name: {{ .name }}
+  name: {{ required (printf "targetGroupConfigurations[%d].name is required" $i) $tgc.name }}
   namespace: {{ template "annuums-gateway.namespace" $ }}
   labels:
     {{- include "annuums-gateway.labels" $ | nindent 4 }}
-    {{- if .labels }}
-    {{- toYaml .labels | nindent 4 }}
+    {{- if $tgc.labels }}
+    {{- toYaml $tgc.labels | nindent 4 }}
     {{- end }}
-  {{- if .annotations }}
+  {{- if $tgc.annotations }}
   annotations:
-    {{- toYaml .annotations | nindent 4 }}
+    {{- toYaml $tgc.annotations | nindent 4 }}
   {{- end }}
 spec:
   targetReference:
-    {{- toYaml .targetReference | nindent 4 }}
-  {{- if .defaultConfiguration }}
+    {{- toYaml (required (printf "targetGroupConfigurations[%d].targetReference is required" $i) $tgc.targetReference) | nindent 4 }}
+  {{- if $tgc.defaultConfiguration }}
   defaultConfiguration:
-    {{- toYaml .defaultConfiguration | nindent 4 }}
+    {{- toYaml $tgc.defaultConfiguration | nindent 4 }}
   {{- end }}
-  {{- if .routeConfigurations }}
+  {{- if $tgc.routeConfigurations }}
   routeConfigurations:
-    {{- toYaml .routeConfigurations | nindent 4 }}
+    {{- toYaml $tgc.routeConfigurations | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/gateway-chart/templates/target-group-configurations.yaml
+++ b/gateway-chart/templates/target-group-configurations.yaml
@@ -1,4 +1,4 @@
-{{- if not (kindIs "slice" .Values.targetGroupConfigurations) }}
+{{- if and .Values.targetGroupConfigurations (not (kindIs "slice" .Values.targetGroupConfigurations)) }}
   {{- fail "targetGroupConfigurations must be a list ([]). See CHANGE_LOG.md" }}
 {{- end }}
 {{- range $i, $tgc := .Values.targetGroupConfigurations }}

--- a/gateway-chart/templates/tls-routes.yaml
+++ b/gateway-chart/templates/tls-routes.yaml
@@ -1,26 +1,26 @@
-{{- range .Values.tlsRoutes }}
+{{- range $i, $route := .Values.tlsRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
-  name: {{ .name }}
+  name: {{ required (printf "tlsRoutes[%d].name is required" $i) $route.name }}
   namespace: {{ template "annuums-gateway.namespace" $ }}
   labels:
     {{- include "annuums-gateway.labels" $ | nindent 4 }}
-    {{- if .labels }}
-    {{- toYaml .labels | nindent 4 }}
+    {{- if $route.labels }}
+    {{- toYaml $route.labels | nindent 4 }}
     {{- end }}
-  {{- if .annotations }}
+  {{- if $route.annotations }}
   annotations:
-    {{- toYaml .annotations | nindent 4 }}
+    {{- toYaml $route.annotations | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml (required (printf "tlsRoutes[%s].parentRefs is required" .name) .parentRefs) | nindent 4 }}
-  {{- if .hostnames }}
+    {{- toYaml (required (printf "tlsRoutes[%d].parentRefs is required" $i) $route.parentRefs) | nindent 4 }}
+  {{- if $route.hostnames }}
   hostnames:
-    {{- toYaml .hostnames | nindent 4 }}
+    {{- toYaml $route.hostnames | nindent 4 }}
   {{- end }}
   rules:
-    {{- toYaml (required (printf "tlsRoutes[%s].rules is required" .name) .rules) | nindent 4 }}
+    {{- toYaml (required (printf "tlsRoutes[%d].rules is required" $i) $route.rules) | nindent 4 }}
 {{- end }}

--- a/gateway-chart/templates/tls-routes.yaml
+++ b/gateway-chart/templates/tls-routes.yaml
@@ -1,7 +1,7 @@
-{{- range .Values.httpRoutes }}
+{{- range .Values.tlsRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+kind: TLSRoute
 metadata:
   name: {{ .name }}
   namespace: {{ template "annuums-gateway.namespace" $ }}

--- a/gateway-chart/templates/tls-routes.yaml
+++ b/gateway-chart/templates/tls-routes.yaml
@@ -16,11 +16,11 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml .parentRefs | nindent 4 }}
+    {{- toYaml (required (printf "tlsRoutes[%s].parentRefs is required" .name) .parentRefs) | nindent 4 }}
   {{- if .hostnames }}
   hostnames:
     {{- toYaml .hostnames | nindent 4 }}
   {{- end }}
   rules:
-    {{- toYaml .rules | nindent 4 }}
+    {{- toYaml (required (printf "tlsRoutes[%s].rules is required" .name) .rules) | nindent 4 }}
 {{- end }}

--- a/gateway-chart/templates/tls-routes.yaml
+++ b/gateway-chart/templates/tls-routes.yaml
@@ -1,4 +1,4 @@
-{{- if not (kindIs "slice" .Values.tlsRoutes) }}
+{{- if and .Values.tlsRoutes (not (kindIs "slice" .Values.tlsRoutes)) }}
   {{- fail "tlsRoutes must be a list ([]). See CHANGE_LOG.md" }}
 {{- end }}
 {{- range $i, $route := .Values.tlsRoutes }}

--- a/gateway-chart/templates/tls-routes.yaml
+++ b/gateway-chart/templates/tls-routes.yaml
@@ -1,3 +1,6 @@
+{{- if not (kindIs "slice" .Values.tlsRoutes) }}
+  {{- fail "tlsRoutes must be a list ([]). See CHANGE_LOG.md" }}
+{{- end }}
 {{- range $i, $route := .Values.tlsRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1

--- a/gateway-chart/test-values.yaml
+++ b/gateway-chart/test-values.yaml
@@ -1,12 +1,16 @@
 fullnameOverride: annuums-gateway
 appVersionSuffix: gateway-chart
-namespace: annuums-gateway
+# namespaceOverride: annuums-gateway
 
 gatewayClass:
   name: my-gateway-class
   annotations: {}
   labels: {}
-  controllerName: my-gateway-controller
+  controllerName: gateway.k8s.aws/alb
+  # parametersRef:
+  #   group: gateway.k8s.aws
+  #   kind: LoadBalancerConfiguration
+  #   name: my-lb-config
 
 gateway:
   className: my-gateway-class
@@ -19,85 +23,165 @@ gateway:
       hostname: example.com
       protocol: HTTP
       allowedRoutes:
-        matchLabels:
-          app: my-app
-          front: react
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              app: my-app
     - name: https
       port: 443
       protocol: HTTPS
       tls:
-        mode: Terminate # If protocol is `TLS`, `Passthrough` is a possible mode
+        mode: Terminate
         certificateRefs:
           - kind: Secret
             group: ""
             name: default-cert
+  # addresses:
+  #   - type: IPAddress
+  #     value: 198.51.100.0
+  # infrastructure:
+  #   labels:
+  #     environment: production
+  #   annotations:
+  #     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 
 httpRoutes:
-  name: my-http-route
-  annotations: {}
-  labels: {}
-  # You can add multiple parentRefs
-  # Usecase: 
-  parentRefs:
-    - name: my-gateway
-    - name: my-gateway-2
-  hostnames:
-    - example.com
-  rules:
-    # example.com/foo -> my-service:80
-    - matches:
-      - path:
-          type: PathPrefix
-          value: /foo
-      backendRefs:
-        - name: my-service
-          port: 80
-    # If you want to fine tune in details, you can add them here
-    - filters:
-      # http://example.com/foo -> https://example.com/foo
-      - type: RequestRedirect
-        requestRedirect:
-          scheme: https
-          statusCode: 301
-    - filters:
-        # example.com/foo -> rew.example.com/foo
-        - type: URLRewrite
-          urlRewrite:
-            hostname: rew.example.com
-    - filters:
+  - name: my-http-route
+    annotations: {}
+    labels: {}
+    parentRefs:
+      - name: my-gateway
+      - name: my-gateway-2
+    hostnames:
+      - example.com
+    rules:
+      # example.com/foo -> my-service:80
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /foo
+        backendRefs:
+          - name: my-service
+            port: 80
+      # http://example.com/* -> https://example.com/*
+      - filters:
+          - type: RequestRedirect
+            requestRedirect:
+              scheme: https
+              statusCode: 301
+      # example.com/foo -> rew.example.com/foo
+      - filters:
+          - type: URLRewrite
+            urlRewrite:
+              hostname: rew.example.com
       # example.com/foo -> rew.example.com/bar
-      - type: URLRewrite
-        urlRewrite:
-          hostname: rew.example.com
-          path:
-            type: ReplaceFullPath
-            replaceFullPath: /bar
-    - filters:
+      - filters:
+          - type: URLRewrite
+            urlRewrite:
+              hostname: rew.example.com
+              path:
+                type: ReplaceFullPath
+                replaceFullPath: /bar
       # example.com/foo/hello -> rew.example.com/bar/hello
-      - type: URLRewrite
-        urlRewrite:
-          hostname: rew.example.com
-          path:
-            type: ReplacePrefixMatch
-            replacePrefixMatch: /bar
+      - filters:
+          - type: URLRewrite
+            urlRewrite:
+              hostname: rew.example.com
+              path:
+                type: ReplacePrefixMatch
+                replacePrefixMatch: /bar
 
 grpcRoutes:
-  name: my-grpc-route
-  annotations: {}
-  labels: {}
-  parentRefs:
-    - name: my-gateway
-  hostnames:
-    - example.com
-  rules:
-  - matches:
-    - headers:
-      - type: Exact
-        name: env
-        value: canary
-    backendRefs:
-    - name: bar-svc-canary
-      port: 50051
-  - backendRefs:
-    - name: bar-svc
-      port: 50051
+  - name: my-grpc-route
+    annotations: {}
+    labels: {}
+    parentRefs:
+      - name: my-gateway
+    hostnames:
+      - example.com
+    rules:
+      - matches:
+          - headers:
+              - type: Exact
+                name: env
+                value: canary
+        backendRefs:
+          - name: bar-svc-canary
+            port: 50051
+      - backendRefs:
+          - name: bar-svc
+            port: 50051
+
+tlsRoutes:
+  - name: my-tls-route
+    annotations: {}
+    labels: {}
+    parentRefs:
+      - name: my-gateway
+        sectionName: tls
+    hostnames:
+      - example.com
+    rules:
+      - backendRefs:
+          - name: my-tls-service
+            port: 443
+
+referenceGrants:
+  - name: allow-gateway-to-app
+    from:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+        namespace: gateway-ns
+    to:
+      - group: ""
+        kind: Service
+
+# AWS Load Balancer Controller custom CRDs
+loadBalancerConfigurations:
+  - name: my-lb-config
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: my-gateway
+    scheme: internet-facing
+    ipAddressType: ipv4
+    # loadBalancerName: my-alb
+    # securityGroups:
+    #   - sg-xxxxxxxxxxxxxxxxx
+    # sourceRanges:
+    #   - 0.0.0.0/0
+    loadBalancerAttributes:
+      - key: deletion_protection.enabled
+        value: "false"
+    listenerConfigurations:
+      - protocolPort: HTTPS:443
+        defaultCertificate: arn:aws:acm:ap-northeast-2:123456789012:certificate/xxxx
+        sslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+    tags:
+      - key: Environment
+        value: production
+    # webACL: arn:aws:wafv2:ap-northeast-2:123456789012:regional/webacl/xxx/xxx
+    mergingMode: prefer-gateway-class
+
+targetGroupConfigurations:
+  - name: my-tg-config
+    targetReference:
+      group: ""
+      kind: Service
+      name: my-service
+    defaultConfiguration:
+      targetType: ip
+      protocol: HTTP
+      protocolVersion: HTTP1
+      healthCheckConfig:
+        path: /health
+        port: 8080
+        protocol: HTTP
+        healthyThresholdCount: 2
+        unhealthyThresholdCount: 3
+        intervalSeconds: 15
+        timeoutSeconds: 5
+      targetGroupAttributes:
+        - key: deregistration_delay.timeout_seconds
+          value: "30"

--- a/gateway-chart/values.yaml
+++ b/gateway-chart/values.yaml
@@ -1,9 +1,19 @@
 fullnameOverride: annuums-gateway
 appVersionSuffix: gateway-chart
-namespace: annuums-gateway
+# namespaceOverride: annuums-gateway
 
 gatewayClass: {}
 
 gateway: {}
 
-httpRoutes: {}
+httpRoutes: []
+
+grpcRoutes: []
+
+tlsRoutes: []
+
+referenceGrants: []
+
+loadBalancerConfigurations: []
+
+targetGroupConfigurations: []


### PR DESCRIPTION
# TL;DR;

[comment]: # "바뀐 내용을 간략하게 설명합니다. 세 줄 이상 넘어가는 경우, PR을 나누는 것을 고려해 보세요."

This pull request introduces a significant update to the `gateway-chart` Helm chart, adding new features, improving flexibility, and aligning with recent Gateway API updates. Notably, it removes the `namespace` field from the cluster-scoped `GatewayClass`, makes `allowedRoutes` and `hostnames` more configurable, supports multiple HTTP/GRPC routes, and adds support for new resource templates and AWS Load Balancer Controller custom CRDs.

**Major changes include:**

### Gateway API Enhancements
- Removed the `namespace` field from the `GatewayClass` resource, as it is cluster-scoped. Added support for optional `parametersRef` and `description` fields in `GatewayClass` for better configuration and documentation. (`gateway-chart/templates/gateway-class.yaml`, `gateway-chart/CHANGE_LOG.md`, [[1]](diffhunk://#diff-0daaa8a7f6a379cdd5fb04b081d40a7b0874c3fa399542e9fa9f517c8d5650d7L6) [[2]](diffhunk://#diff-0daaa8a7f6a379cdd5fb04b081d40a7b0874c3fa399542e9fa9f517c8d5650d7R17-R23) [[3]](diffhunk://#diff-10a3727f8149f7f9def8c84e7458aec701e9cfcf1d8159b944d36264b1fea580R3-R15)
- `allowedRoutes` in Gateway listeners is now fully configurable (previously hardcoded to `from: Selector`), and `hostnames` in HTTPRoute/GRPCRoute are now optional and only rendered when set. (`gateway-chart/templates/gateway.yaml`, `gateway-chart/CHANGE_LOG.md`, [[1]](diffhunk://#diff-4af2275e5b852acdec6fb12cb267d5a05f4957b2824f7938972dd09219baa8cbR31-R57) [[2]](diffhunk://#diff-10a3727f8149f7f9def8c84e7458aec701e9cfcf1d8159b944d36264b1fea580R3-R15)

### Resource Template Additions
- Added templates for `TLSRoute`, `ReferenceGrant`, `LoadBalancerConfiguration`, and `TargetGroupConfiguration`, supporting new Gateway API features and AWS LBC custom CRDs. (`gateway-chart/templates/tls-routes.yaml`, `gateway-chart/templates/reference-grants.yaml`, `gateway-chart/templates/load-balancer-configurations.yaml`, `gateway-chart/templates/target-group-configurations.yaml`, [[1]](diffhunk://#diff-f9d3913ef700714f9e69c7a8a9225f87ee7ef045899e961e6169af327c02b13aR1-R26) [[2]](diffhunk://#diff-32ab6d49113bd1a9c469254b2b62b3bf46850f328ad9f06672f370cfc5478a1aR1-R22) [[3]](diffhunk://#diff-720b65919fe6a336ac8efb78942a1249a124626c00894a0724f99ebf90fbf197R1-R65) [[4]](diffhunk://#diff-be7b6b0e79e68d0eb323667ff51c9f3da77c2f64791b0d38a75ebe31f6770ed7R1-R28) [[5]](diffhunk://#diff-10a3727f8149f7f9def8c84e7458aec701e9cfcf1d8159b944d36264b1fea580R3-R15)

### Improved Route Configuration
- Changed `httpRoutes` and `grpcRoutes` from a single object to a list, allowing multiple routes per release. Updated templates to iterate over these lists and render multiple route resources. (`gateway-chart/templates/http-routes.yaml`, `gateway-chart/templates/grpc-routes.yaml`, `gateway-chart/values.yaml`, `gateway-chart/test-values.yaml`, [[1]](diffhunk://#diff-452e0c266d9bd8838be105cca3b2172366bd9b21ac2fd438d0f2fcb000e3a63fL1-R25) [[2]](diffhunk://#diff-69797a17130a204b40a5592a3a5c1d53075c6b65a9aa3793c7ec94fd37dd153dL1-R25) [[3]](diffhunk://#diff-64878bad3e9a8d0c87f6b244a23dd152aafeb965918fe0ba4b19400817a7fd99L3-R19) [[4]](diffhunk://#diff-10a3727f8149f7f9def8c84e7458aec701e9cfcf1d8159b944d36264b1fea580R3-R15)

### Values and Test Values Updates
- Updated `values.yaml` and `test-values.yaml` to reflect new structure and support for lists and new fields, including examples for new templates and fields such as `addresses`, `infrastructure`, and AWS-specific configurations. (`gateway-chart/values.yaml`, `gateway-chart/test-values.yaml`, [[1]](diffhunk://#diff-64878bad3e9a8d0c87f6b244a23dd152aafeb965918fe0ba4b19400817a7fd99L3-R19) [[2]](diffhunk://#diff-7a58c07d2ed7d6b282c4e6f2e29e552ccfcbff3d2d632dc8a63041931b253f42L3-R13) [[3]](diffhunk://#diff-7a58c07d2ed7d6b282c4e6f2e29e552ccfcbff3d2d632dc8a63041931b253f42R26-L40) [[4]](diffhunk://#diff-7a58c07d2ed7d6b282c4e6f2e29e552ccfcbff3d2d632dc8a63041931b253f42L55-R87) [[5]](diffhunk://#diff-7a58c07d2ed7d6b282c4e6f2e29e552ccfcbff3d2d632dc8a63041931b253f42L85-R96) [[6]](diffhunk://#diff-7a58c07d2ed7d6b282c4e6f2e29e552ccfcbff3d2d632dc8a63041931b253f42R115-R187)

### Version Bump and Changelog
- Bumped chart version to `0.1.0` and updated the changelog to document all new features and fixes. (`gateway-chart/Chart.yaml`, `gateway-chart/CHANGE_LOG.md`, [[1]](diffhunk://#diff-35247a5f5655da9b7966fa44a3150ba0d54de5b65a13d6dc65e057ec06ed61acL5-R5) [[2]](diffhunk://#diff-10a3727f8149f7f9def8c84e7458aec701e9cfcf1d8159b944d36264b1fea580R3-R15)

# Updates

[comment]: # "변경 사항을 모두 작성합니다."

# Discussion

[comment]: # "함께 의논해야 할 사항을 모두 작성합니다."

# Checklist

- [x] PR 제목을 `[변경된 차트 명 버전] 변경된 내용`을 명령형으로 작성했습니다.
  - 예시)
    - `[Deployment-Chart 0.0.1] Fix app version`
- [x] 연관된 차트를 Labels로 표기했습니다.
- [x] Updates에 변경 사항을 자세히 기록했습니다.
- [x] 이해되지 않는 내용이나, 추가 논의 사항을 Discussion을 작성했습니다.
- [x] Self Review를 진행했습니다.
- [x] 연관된 사람을 Reviewer로 요청했습니다.
