### PR TITLE
[cronjob-chart 0.7.8] fix: cronjob chart service account template referencing wrong chart

### DIFF
--- a/cronjob-chart/CHANGE_LOG.md
+++ b/cronjob-chart/CHANGE_LOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.8
+- fix: cronjob chart service account template referencing wrong chart
+
 ## 0.7.7
 - fix: add missing labels to service account
 

--- a/cronjob-chart/Chart.yaml
+++ b/cronjob-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: A Helm chart for Kubernetes CronJob Object in Annuums
 name: cronjob-chart
 type: application
-version: 0.7.7
+version: 0.7.8

--- a/cronjob-chart/templates/service-account.yaml
+++ b/cronjob-chart/templates/service-account.yaml
@@ -9,8 +9,8 @@ metadata:
     {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}
   labels:
-    annuums.obs/version: {{ template "annuums-deployment.chart" . }}
-    {{- include "annuums-deployment.labels" . | nindent 4 }}
+    annuums.obs/version: {{ template "annuums-cronjob.chart" . }}
+    {{- include "annuums-cronjob.labels" . | nindent 4 }}
     {{- if .Values.labels }}
     {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
# TL;DR;

[comment]: # "바뀐 내용을 간략하게 설명합니다. 세 줄 이상 넘어가는 경우, PR을 나누는 것을 고려해 보세요."
- fix: cronjob chart service account template referencing wrong chart
  - helper currently referencing deployment and fix it to cronjob

# Updates

[comment]: # "변경 사항을 모두 작성합니다."

This pull request updates the Kubernetes chart templates for the cronjob service account to reference the correct chart and labels. The main change ensures that the metadata in `service-account.yaml` uses the `annuums-cronjob` chart and labels instead of the `annuums-deployment` ones.

Chart and label reference updates:

* Updated the `annuums.obs/version` label and the included labels in `cronjob-chart/templates/service-account.yaml` to use `annuums-cronjob` instead of `annuums-deployment`.

# Discussion

[comment]: # "함께 의논해야 할 사항을 모두 작성합니다."

# Checklist

- [x] PR 제목을 `[변경된 차트 명 버전] 변경된 내용`을 명령형으로 작성했습니다.
  - 예시)
    - `[Deployment-Chart 0.0.1] Fix app version`
- [X] 연관된 차트를 Labels로 표기했습니다.
- [x] Updates에 변경 사항을 자세히 기록했습니다.
- [x] 이해되지 않는 내용이나, 추가 논의 사항을 Discussion을 작성했습니다.
- [x] Self Review를 진행했습니다.
- [x] 연관된 사람을 Reviewer로 요청했습니다.
